### PR TITLE
XDR: Add host identification for AuditD logs

### DIFF
--- a/config/auditd.conf
+++ b/config/auditd.conf
@@ -40,7 +40,7 @@ priority_boost = 4
 # Host Identification Configuration
 # Define user here if you wish to provide the name
 # Otherwise you can choose None, hostname, fqd, or numeric
-name_format = NONE
+name_format = hostname
 #name = mydomain
 
 # Disk Space Configurations


### PR DESCRIPTION
We could have used `fqd` or `numeric` as well, 
`fqd`: takes the hostname and resolves it with dns for a fully qualified domain name of that machine. 
`numeric`: resolves the IP address of the machine. 
> **Warning**
> `numeric` option is not recommended if dhcp is used because you could have different addresses over time for the same machine.